### PR TITLE
Update grype ignore list

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -55,6 +55,8 @@ jobs:
           cat ${{ steps.scan.outputs.sarif }} | jq '.runs[0].tool.driver.rules[].shortDescription.text' | grep -i "medium" || true
           cat ${{ steps.scan.outputs.sarif }} | jq '.runs[0].tool.driver.rules[].shortDescription.text' | grep -i "low" || true
           cat ${{ steps.scan.outputs.sarif }} | jq '.runs[0].tool.driver.rules[].shortDescription.text' | grep -iv "critical\|high\|medium\|low" || true
+          echo "Details:"
+          cat ${{ steps.scan.outputs.sarif }}
 
       - name: Publish Scan Results as Artifact
         if: always()

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -55,8 +55,6 @@ jobs:
           cat ${{ steps.scan.outputs.sarif }} | jq '.runs[0].tool.driver.rules[].shortDescription.text' | grep -i "medium" || true
           cat ${{ steps.scan.outputs.sarif }} | jq '.runs[0].tool.driver.rules[].shortDescription.text' | grep -i "low" || true
           cat ${{ steps.scan.outputs.sarif }} | jq '.runs[0].tool.driver.rules[].shortDescription.text' | grep -iv "critical\|high\|medium\|low" || true
-          echo "Details:"
-          cat ${{ steps.scan.outputs.sarif }}
 
       - name: Publish Scan Results as Artifact
         if: always()

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -3,5 +3,7 @@ ignore:
 
   # CVE-2015-5237 high vulnerability for google.golang.org/protobuf package
   # https://nvd.nist.gov/vuln/detail/CVE-2015-5237
-  # Need to research -- adding it to ignore for the moment
-  # - vulnerability: CVE-2015-5237
+  - vulnerability: CVE-2015-5237
+    package:
+      name: google.golang.org/protobuf
+      location: /usr/local/bin/kubectl

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -4,4 +4,4 @@ ignore:
   # CVE-2015-5237 high vulnerability for google.golang.org/protobuf package
   # https://nvd.nist.gov/vuln/detail/CVE-2015-5237
   # Need to research -- adding it to ignore for the moment
-  - vulnerability: CVE-2015-5237
+  # - vulnerability: CVE-2015-5237


### PR DESCRIPTION
Updated the grype ignore.  groudnuty repo exempts kubectl binary from all vulnerability scans.  Add ignore for the explicit CVE only for kubectl.