### PR TITLE
Use current CA certs.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.16.2 AS builder
 
 ARG TARGETARCH
 
-RUN apk add --update --no-cache ca-certificates=20220614-r0 curl=8.0.1-r0 jq=1.6-r1 \
+RUN apk add --update --no-cache ca-certificates curl=8.0.1-r0 jq=1.6-r1 \
     && KUBECTL_LATEST_STABLE_VERSION=$(curl -L https://dl.k8s.io/release/stable.txt) \
     && curl -L https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_LATEST_STABLE_VERSION}/bin/linux/$TARGETARCH/kubectl -o /usr/local/bin/kubectl \
     && chmod +x /usr/local/bin/kubectl

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ ENV UID=1100
 ENV GID=1100
 
 RUN apk -U --no-cache upgrade && \
-    apk add --update --no-cache ca-certificates=20220614-r0 jq=1.6-r1 && \
+    apk add --update --no-cache jq=1.6-r1 && \
     addgroup -g $GID $USER && \
     adduser \
     --disabled-password \


### PR DESCRIPTION
Over the weekend the daily build failed because of the apk update pulling in a new version of CA certs -- removed the hardcoded 2022 version. 