### PR TITLE
update github actions to leverage ubuntu 24.04 base image.

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -160,11 +160,12 @@ jobs:
           sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
           sudo docker run hello-world
           
-          KUBECTL_LATEST_STABLE_VERSION=$(curl -L https://dl.k8s.io/release/stable.txt)
-          echo "kubectl version: ${KUBECTL_LATEST_STABLE_VERSION}" 
-          sudo curl -L "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd/kubectl" -o /usr/local/bin/kubectl
-          sudo chmod +x /usr/local/bin/kubectl
-          ls -al /usr/local/bin/kubectl
+          curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.33/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+          sudo chmod 644 /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+          echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.33/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
+          sudo chmod 644 /etc/apt/sources.list.d/kubernetes.list
+          sudo apt-get update
+          sudo apt-get install -y kubectl
           
           curl -Lo minikube https://github.com/kubernetes/minikube/releases/latest/download/minikube-linux-amd64 && install minikube-linux-amd64 /usr/local/bin/minikube && rm minikube-linux-amd64
           mkdir -p $HOME/.kube $HOME/.minikube

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -152,6 +152,7 @@ jobs:
           sudo systemctl enable cri-docker.service
           sudo systemctl enable --now cri-docker.socket
           sudo systemctl daemon-reload
+          journalctl -u cri-docker.service
           echo "8"
           sudo systemctl status cri-docker
           echo "9"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -175,6 +175,7 @@ jobs:
 
       - name: Ensure kubernetes is ready
         run: |
+          kubectl get pods -A
           kubectl cluster-info
           JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl -n kube-system get pods -lk8s-app=kube-dns -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1;echo "waiting for kube-dns to be available"; kubectl get pods --all-namespaces; done
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -140,6 +140,10 @@ jobs:
           curl -o bash_unit "https://raw.githubusercontent.com/pgrange/bash_unit/master/bash_unit"
           chmod +x bash_unit
           
+          curl -Lo runc.amd64 https://github.com/opencontainers/runc/releases/download/v1.3.0/runc.amd64
+          sudo install runc.amd64 /usr/local/bin/runc
+          rm runc.amd64
+          
           curl -Lo cri-dockerd.tgz https://github.com/Mirantis/cri-dockerd/releases/download/v0.3.17/cri-dockerd-0.3.17.amd64.tgz
           tar -xzvf cri-dockerd.tgz
           sudo install -o root -g root -m 0755 cri-dockerd/cri-dockerd /usr/local/bin/cri-dockerd

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -160,12 +160,9 @@ jobs:
           sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
           sudo docker run hello-world
           
-          curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.33/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
-          sudo chmod 644 /etc/apt/keyrings/kubernetes-apt-keyring.gpg
-          echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.33/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
-          sudo chmod 644 /etc/apt/sources.list.d/kubernetes.list
-          sudo apt-get update
-          sudo apt-get install -y kubectl
+          curl -Lo kubectl https://dl.k8s.io/release/v1.33.0/bin/linux/amd64/kubectl
+          chmod +x kubectl
+          sudo cp kubectl /usr/local/bin
           
           curl -Lo minikube https://github.com/kubernetes/minikube/releases/latest/download/minikube-linux-amd64 && install minikube-linux-amd64 /usr/local/bin/minikube && rm minikube-linux-amd64
           mkdir -p $HOME/.kube $HOME/.minikube

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
         with:
@@ -26,7 +26,7 @@ jobs:
         run: make images
   scan:
     needs: [ "build" ]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -161,7 +161,7 @@ jobs:
           sudo docker run hello-world
           
           
-          curl -Lo kubectl https://dl.k8s.io/release/v1.33.1/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+          curl -Lo kubectl https://dl.k8s.io/release/v1.31.0/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
           curl -Lo minikube https://github.com/kubernetes/minikube/releases/latest/download/minikube-linux-amd64 && install minikube-linux-amd64 /usr/local/bin/minikube && rm minikube-linux-amd64
           mkdir -p $HOME/.kube $HOME/.minikube
           touch $KUBECONFIG
@@ -176,7 +176,7 @@ jobs:
       - name: Ensure kubernetes is ready
         run: |
           set -x
-          minikube kubectl get pods --all-namespaces
+          minikube kubectl -- get pods -A
           kubectl cluster-info
           JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl -n kube-system get pods -lk8s-app=kube-dns -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1;echo "waiting for kube-dns to be available"; kubectl get pods --all-namespaces; done
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -142,11 +142,16 @@ jobs:
           curl -Lo cri-dockerd.tgz https://github.com/Mirantis/cri-dockerd/releases/download/v0.3.17/cri-dockerd-0.3.17.amd64.tgz
           tar -xzvf cri-dockerd.tgz
           cp cri-dockerd/cri-dockerd /usr/local/bin
-          
           rm cri-dockerd.tgz
+          
           curl -Lo crictl.tar.gz https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.33.0/crictl-v1.33.0-linux-amd64.tar.gz
           tar zxvf crictl.tar.gz -C /usr/local/bin
           rm -f crictl.tar.gz
+          
+          curl -Lo cni-plugins.tgz https://github.com/containernetworking/plugins/releases/download/v1.7.1/cni-plugins-linux-amd64-v1.7.1.tgz
+          sudo mkdir -p /opt/cni/bin
+          sudo tar -xf cni-plugins.tgz -C /opt/cni/bin
+          rm cni-plugins.tgz
           
           curl -Lo kubectl https://dl.k8s.io/release/v1.33.1/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
           curl -Lo minikube https://github.com/kubernetes/minikube/releases/latest/download/minikube-linux-amd64 && install minikube-linux-amd64 /usr/local/bin/minikube && rm minikube-linux-amd64

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -138,6 +138,10 @@ jobs:
         run: |
           curl -o bash_unit "https://raw.githubusercontent.com/pgrange/bash_unit/master/bash_unit"
           chmod +x bash_unit
+          VERSION="v1.33.0"
+          curl -Lo https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/crictl-$VERSION-linux-amd64.tar.gz
+          tar zxvf crictl-$VERSION-linux-amd64.tar.gz -C /usr/local/bin
+          rm -f crictl-$VERSION-linux-amd64.tar.gz
           curl -Lo kubectl https://dl.k8s.io/release/v1.33.1/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
           curl -Lo minikube https://github.com/kubernetes/minikube/releases/latest/download/minikube-linux-amd64 && install minikube-linux-amd64 /usr/local/bin/minikube && rm minikube-linux-amd64
           mkdir -p $HOME/.kube $HOME/.minikube

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -138,15 +138,37 @@ jobs:
         run: |
           curl -o bash_unit "https://raw.githubusercontent.com/pgrange/bash_unit/master/bash_unit"
           chmod +x bash_unit
+          
+          echo "[Unit]" > /etc/systemd/system/cri-docker.service
+          echo "Description=CRI-Dockerd service" >> /etc/systemd/system/cri-docker.service
+          echo "Wants=docker.service" >> /etc/systemd/system/cri-docker.service
+          echo "After=docker.service" >> /etc/systemd/system/cri-docker.service
+          echo "" >> /etc/systemd/system/cri-docker.service
+          echo "[Service]" >> /etc/systemd/system/cri-docker.service
+          echo "Type=simple" >> /etc/systemd/system/cri-docker.service
+          echo "ExecStart=/usr/local/bin/cri-dockerd" >> /etc/systemd/system/cri-docker.service
+          echo "User=root" >> /etc/systemd/system/cri-docker.service
+          echo "Environment=DOCKER_HOST=localhost" >> /etc/systemd/system/cri-docker.service
+          echo "Restart=on-failure" >> /etc/systemd/system/cri-docker.service
+          echo "" >> /etc/systemd/system/cri-docker.service
+          echo "[Install]" >> /etc/systemd/system/cri-docker.service
+          echo "WantedBy=multi-user.target" >> /etc/systemd/system/cri-docker.service
+          
+          curl -Lo cri-dockerd.tgz https://github.com/Mirantis/cri-dockerd/releases/download/v0.3.17/cri-dockerd-0.3.17.amd64.tgz
+          tar -xzvf cri-dockerd.tgz
+          cp cri-dockerd/cri-dockerd /usr/local/bin
+          
+          rm cri-dockerd.tgz
           curl -Lo crictl.tar.gz https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.33.0/crictl-v1.33.0-linux-amd64.tar.gz
           tar zxvf crictl.tar.gz -C /usr/local/bin
           rm -f crictl.tar.gz
+          
           curl -Lo kubectl https://dl.k8s.io/release/v1.33.1/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
           curl -Lo minikube https://github.com/kubernetes/minikube/releases/latest/download/minikube-linux-amd64 && install minikube-linux-amd64 /usr/local/bin/minikube && rm minikube-linux-amd64
           mkdir -p $HOME/.kube $HOME/.minikube
           touch $KUBECONFIG
           sudo apt-get install -y conntrack
-          minikube start --vm-driver=none --kubernetes-version=v1.33.1
+          minikube start --vm-driver=none --kubernetes-version=v1.31.0
           echo "minikube startup complete."
           docker save -o k8s-wait-for-test pegasystems/k8s-wait-for:test
           minikube image load k8s-wait-for-test

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -176,7 +176,7 @@ jobs:
       - name: Ensure kubernetes is ready
         run: |
           set -x
-          kubectl minikube get pods -A
+          minikube kubectl get pods -A
           kubectl cluster-info
           JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl -n kube-system get pods -lk8s-app=kube-dns -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1;echo "waiting for kube-dns to be available"; kubectl get pods --all-namespaces; done
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -149,6 +149,9 @@ jobs:
           sudo install cri-docker.service /etc/systemd/system
           sudo install cri-docker.socket /etc/systemd/system
           sudo sed -i -e 's,/usr/bin/cri-dockerd,/usr/local/bin/cri-dockerd,' /etc/systemd/system/cri-docker.service
+          
+          which cri-dockerd
+          
           sudo systemctl enable cri-docker.service
           sudo systemctl enable --now cri-docker.socket
           sudo systemctl daemon-reload

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -141,7 +141,7 @@ jobs:
           
           curl -Lo cri-dockerd.tgz https://github.com/Mirantis/cri-dockerd/releases/download/v0.3.17/cri-dockerd-0.3.17.amd64.tgz
           tar -xzvf cri-dockerd.tgz
-          install -o root -g root -m 0755 cri-dockerd /usr/local/bin/cri-dockerd
+          install -o root -g root -m 0755 cri-dockerd/cri-dockerd /usr/local/bin/cri-dockerd
           curl -Lo cri-docker.service https://raw.githubusercontent.com/Mirantis/cri-dockerd/master/packaging/systemd/cri-docker.service
           curl -Lo cri-docker.socket https://raw.githubusercontent.com/Mirantis/cri-dockerd/master/packaging/systemd/cri-docker.socket
           install cri-docker.service /etc/systemd/system

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -142,13 +142,20 @@ jobs:
           curl -Lo cri-dockerd.tgz https://github.com/Mirantis/cri-dockerd/releases/download/v0.3.17/cri-dockerd-0.3.17.amd64.tgz
           tar -xzvf cri-dockerd.tgz
           sudo install -o root -g root -m 0755 cri-dockerd/cri-dockerd /usr/local/bin/cri-dockerd
+          echo "3"
           curl -Lo cri-docker.service https://raw.githubusercontent.com/Mirantis/cri-dockerd/master/packaging/systemd/cri-docker.service
           curl -Lo cri-docker.socket https://raw.githubusercontent.com/Mirantis/cri-dockerd/master/packaging/systemd/cri-docker.socket
+          echo "4"
           sudo install cri-docker.service /etc/systemd/system
+          echo "5"
           sudo install cri-docker.socket /etc/systemd/system
+          echo "6"
           sudo sed -i -e 's,/usr/bin/cri-dockerd,/usr/local/bin/cri-dockerd,' /etc/systemd/system/cri-docker.service
+          echo "systemctl daemon-reload"
           sudo systemctl daemon-reload
+          echo "7"
           sudo systemctl enable --now cri-docker.socket
+          echo "8"
           sudo systemctl status cri-docker
           rm cri-dockerd.tgz
           rm cri-docker.service

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -138,10 +138,9 @@ jobs:
         run: |
           curl -o bash_unit "https://raw.githubusercontent.com/pgrange/bash_unit/master/bash_unit"
           chmod +x bash_unit
-          VERSION="v1.33.0"
-          curl -Lo https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/crictl-$VERSION-linux-amd64.tar.gz
-          tar zxvf crictl-$VERSION-linux-amd64.tar.gz -C /usr/local/bin
-          rm -f crictl-$VERSION-linux-amd64.tar.gz
+          curl -Lo crictl.tar.gz https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.33.0/crictl-v1.33.0-linux-amd64.tar.gz
+          tar zxvf crictl.tar.gz -C /usr/local/bin
+          rm -f crictl.tar.gz
           curl -Lo kubectl https://dl.k8s.io/release/v1.33.1/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
           curl -Lo minikube https://github.com/kubernetes/minikube/releases/latest/download/minikube-linux-amd64 && install minikube-linux-amd64 /usr/local/bin/minikube && rm minikube-linux-amd64
           mkdir -p $HOME/.kube $HOME/.minikube

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -141,15 +141,15 @@ jobs:
           
           curl -Lo cri-dockerd.tgz https://github.com/Mirantis/cri-dockerd/releases/download/v0.3.17/cri-dockerd-0.3.17.amd64.tgz
           tar -xzvf cri-dockerd.tgz
-          install -o root -g root -m 0755 cri-dockerd/cri-dockerd /usr/local/bin/cri-dockerd
+          sudo install -o root -g root -m 0755 cri-dockerd/cri-dockerd /usr/local/bin/cri-dockerd
           curl -Lo cri-docker.service https://raw.githubusercontent.com/Mirantis/cri-dockerd/master/packaging/systemd/cri-docker.service
           curl -Lo cri-docker.socket https://raw.githubusercontent.com/Mirantis/cri-dockerd/master/packaging/systemd/cri-docker.socket
-          install cri-docker.service /etc/systemd/system
-          install cri-docker.socket /etc/systemd/system
-          sed -i -e 's,/usr/bin/cri-dockerd,/usr/local/bin/cri-dockerd,' /etc/systemd/system/cri-docker.service
-          systemctl daemon-reload
-          systemctl enable --now cri-docker.socket
-          systemctl status cri-docker
+          sudo install cri-docker.service /etc/systemd/system
+          sudo install cri-docker.socket /etc/systemd/system
+          sudo sed -i -e 's,/usr/bin/cri-dockerd,/usr/local/bin/cri-dockerd,' /etc/systemd/system/cri-docker.service
+          sudo systemctl daemon-reload
+          sudo systemctl enable --now cri-docker.socket
+          sudo systemctl status cri-docker
           rm cri-dockerd.tgz
           rm cri-docker.service
           rm cri-docker.socket

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -163,7 +163,7 @@ jobs:
           KUBECTL_LATEST_STABLE_VERSION=$(curl -L https://dl.k8s.io/release/stable.txt)
           echo "kubectl version: ${KUBECTL_LATEST_STABLE_VERSION}" 
           sudo curl -L "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/$TARGETARCH/kubectl" -o /usr/local/bin/kubectl
-          chmod +x /usr/local/bin/kubectl
+          sudo chmod +x /usr/local/bin/kubectl
           
           curl -Lo minikube https://github.com/kubernetes/minikube/releases/latest/download/minikube-linux-amd64 && install minikube-linux-amd64 /usr/local/bin/minikube && rm minikube-linux-amd64
           mkdir -p $HOME/.kube $HOME/.minikube

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -142,23 +142,17 @@ jobs:
           curl -Lo cri-dockerd.tgz https://github.com/Mirantis/cri-dockerd/releases/download/v0.3.17/cri-dockerd-0.3.17.amd64.tgz
           tar -xzvf cri-dockerd.tgz
           sudo install -o root -g root -m 0755 cri-dockerd/cri-dockerd /usr/local/bin/cri-dockerd
-          echo "3"
+
           curl -Lo cri-docker.service https://raw.githubusercontent.com/Mirantis/cri-dockerd/master/packaging/systemd/cri-docker.service
           curl -Lo cri-docker.socket https://raw.githubusercontent.com/Mirantis/cri-dockerd/master/packaging/systemd/cri-docker.socket
-          echo "4"
           sudo install cri-docker.service /etc/systemd/system
-          echo "5"
           sudo install cri-docker.socket /etc/systemd/system
-          echo "6"
           sudo sed -i -e 's,/usr/bin/cri-dockerd,/usr/local/bin/cri-dockerd,' /etc/systemd/system/cri-docker.service
-          echo "systemctl daemon-reload"
           sudo systemctl daemon-reload
-          echo "7"
           sudo systemctl enable cri-docker.service
-          echo "7.5"
           sudo systemctl enable --now cri-docker.socket
+          sudo systemctl daemon-reload
           echo "8"
-          echo "8.5"
           sudo systemctl status cri-docker
           echo "9"
           rm cri-dockerd.tgz

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -156,6 +156,8 @@ jobs:
           echo "7"
           sudo systemctl enable --now cri-docker.socket
           echo "8"
+          sudo systemctl restart docker
+          echo "8.5"
           sudo systemctl status cri-docker
           echo "9"
           rm cri-dockerd.tgz

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -139,21 +139,6 @@ jobs:
           curl -o bash_unit "https://raw.githubusercontent.com/pgrange/bash_unit/master/bash_unit"
           chmod +x bash_unit
           
-          sudo echo "[Unit]" > /etc/systemd/system/cri-docker.service
-          sudo echo "Description=CRI-Dockerd service" >> /etc/systemd/system/cri-docker.service
-          sudo echo "Wants=docker.service" >> /etc/systemd/system/cri-docker.service
-          sudo echo "After=docker.service" >> /etc/systemd/system/cri-docker.service
-          sudo echo "" >> /etc/systemd/system/cri-docker.service
-          sudo echo "[Service]" >> /etc/systemd/system/cri-docker.service
-          sudo echo "Type=simple" >> /etc/systemd/system/cri-docker.service
-          sudo echo "ExecStart=/usr/local/bin/cri-dockerd" >> /etc/systemd/system/cri-docker.service
-          sudo echo "User=root" >> /etc/systemd/system/cri-docker.service
-          sudo echo "Environment=DOCKER_HOST=localhost" >> /etc/systemd/system/cri-docker.service
-          sudo echo "Restart=on-failure" >> /etc/systemd/system/cri-docker.service
-          sudo echo "" >> /etc/systemd/system/cri-docker.service
-          sudo echo "[Install]" >> /etc/systemd/system/cri-docker.service
-          sudo echo "WantedBy=multi-user.target" >> /etc/systemd/system/cri-docker.service
-          
           curl -Lo cri-dockerd.tgz https://github.com/Mirantis/cri-dockerd/releases/download/v0.3.17/cri-dockerd-0.3.17.amd64.tgz
           tar -xzvf cri-dockerd.tgz
           cp cri-dockerd/cri-dockerd /usr/local/bin

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -141,8 +141,18 @@ jobs:
           
           curl -Lo cri-dockerd.tgz https://github.com/Mirantis/cri-dockerd/releases/download/v0.3.17/cri-dockerd-0.3.17.amd64.tgz
           tar -xzvf cri-dockerd.tgz
-          cp cri-dockerd/cri-dockerd /usr/local/bin
+          install -o root -g root -m 0755 cri-dockerd /usr/local/bin/cri-dockerd
+          curl -Lo cri-docker.service https://raw.githubusercontent.com/Mirantis/cri-dockerd/master/packaging/systemd/cri-docker.service
+          curl -Lo cri-docker.socket https://raw.githubusercontent.com/Mirantis/cri-dockerd/master/packaging/systemd/cri-docker.socket
+          install cri-docker.service /etc/systemd/system
+          install cri-docker.socket /etc/systemd/system
+          sed -i -e 's,/usr/bin/cri-dockerd,/usr/local/bin/cri-dockerd,' /etc/systemd/system/cri-docker.service
+          systemctl daemon-reload
+          systemctl enable --now cri-docker.socket
+          systemctl status cri-docker
           rm cri-dockerd.tgz
+          rm cri-docker.service
+          rm cri-docker.socket
           
           curl -Lo crictl.tar.gz https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.33.0/crictl-v1.33.0-linux-amd64.tar.gz
           tar zxvf crictl.tar.gz -C /usr/local/bin

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -80,7 +80,7 @@ jobs:
   deploy:
     name: Push to DockerHub
     if: ${{ github.ref == 'refs/heads/master' && github.repository == 'pegasystems/k8s-wait-for' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [scan, test]
     steps:
       - name: Login to Docker Hub
@@ -95,7 +95,7 @@ jobs:
 
   test:
     name: Container Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: always()
     needs: [build, scan]
     env:
@@ -138,12 +138,12 @@ jobs:
         run: |
           curl -o bash_unit "https://raw.githubusercontent.com/pgrange/bash_unit/master/bash_unit"
           chmod +x bash_unit
-          curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.23.15/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
-          curl -Lo minikube https://storage.googleapis.com/minikube/releases/v1.28.0/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+          curl -Lo kubectl https://dl.k8s.io/release/v1.33.1/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+          curl -Lo minikube https://github.com/kubernetes/minikube/releases/latest/download/minikube-linux-amd64 && install minikube-linux-amd64 /usr/local/bin/minikube && rm minikube-linux-amd64
           mkdir -p $HOME/.kube $HOME/.minikube
           touch $KUBECONFIG
           sudo apt-get install -y conntrack
-          minikube start --vm-driver=none --kubernetes-version=v1.23.15
+          minikube start --vm-driver=none --kubernetes-version=v1.33.1
           echo "minikube startup complete."
           docker save -o k8s-wait-for-test pegasystems/k8s-wait-for:test
           minikube image load k8s-wait-for-test

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -151,6 +151,7 @@ jobs:
           sudo sed -i -e 's,/usr/bin/cri-dockerd,/usr/local/bin/cri-dockerd,' /etc/systemd/system/cri-docker.service
           
           which cri-dockerd
+          cri-dockerd --help
           
           sudo systemctl enable cri-docker.service
           sudo systemctl enable --now cri-docker.socket

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -163,7 +163,9 @@ jobs:
           KUBECTL_LATEST_STABLE_VERSION=$(curl -L https://dl.k8s.io/release/stable.txt)
           echo "kubectl version: ${KUBECTL_LATEST_STABLE_VERSION}" 
           sudo curl -L "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/$TARGETARCH/kubectl" -o /usr/local/bin/kubectl
+          sudo cp kubectl /usr/local/bin/
           sudo chmod +x /usr/local/bin/kubectl
+          ls -al /usr/local/bin/kubectl
           
           curl -Lo minikube https://github.com/kubernetes/minikube/releases/latest/download/minikube-linux-amd64 && install minikube-linux-amd64 /usr/local/bin/minikube && rm minikube-linux-amd64
           mkdir -p $HOME/.kube $HOME/.minikube

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -162,8 +162,7 @@ jobs:
           
           KUBECTL_LATEST_STABLE_VERSION=$(curl -L https://dl.k8s.io/release/stable.txt)
           echo "kubectl version: ${KUBECTL_LATEST_STABLE_VERSION}" 
-          sudo curl -L "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/$TARGETARCH/kubectl" -o /usr/local/bin/kubectl
-          sudo cp kubectl /usr/local/bin/
+          sudo curl -L "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd/kubectl" -o /usr/local/bin/kubectl
           sudo chmod +x /usr/local/bin/kubectl
           ls -al /usr/local/bin/kubectl
           

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -160,8 +160,11 @@ jobs:
           sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
           sudo docker run hello-world
           
+          KUBECTL_LATEST_STABLE_VERSION=$(curl -L https://dl.k8s.io/release/stable.txt)
+          echo "kubectl version: ${KUBECTL_LATEST_STABLE_VERSION}" 
+          sudo curl -L "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/$TARGETARCH/kubectl" -o /usr/local/bin/kubectl
+          chmod +x /usr/local/bin/kubectl
           
-          curl -Lo kubectl https://dl.k8s.io/release/v1.31.0/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
           curl -Lo minikube https://github.com/kubernetes/minikube/releases/latest/download/minikube-linux-amd64 && install minikube-linux-amd64 /usr/local/bin/minikube && rm minikube-linux-amd64
           mkdir -p $HOME/.kube $HOME/.minikube
           touch $KUBECONFIG

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -154,6 +154,8 @@ jobs:
           sudo systemctl daemon-reload
           journalctl -u cri-docker.service
           echo "8"
+          sudo service cri-docker.service status
+          sudo service cri-docker.socket status
           sudo systemctl status cri-docker
           echo "9"
           rm cri-dockerd.tgz

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -153,9 +153,8 @@ jobs:
           sudo systemctl enable --now cri-docker.socket
           sudo systemctl daemon-reload
           echo "8"
-          sudo service cri-docker status || true
           sudo systemctl status cri-docker || true
-          journalctl -u cri-docker.service
+          journalctl -xeu cri-docker.service
           echo "9"
           rm cri-dockerd.tgz
           rm cri-docker.service

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -177,6 +177,7 @@ jobs:
         run: |
           set -x
           minikube kubectl -- get pods -A
+          kubectl --help
           kubectl cluster-info
           JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl -n kube-system get pods -lk8s-app=kube-dns -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1;echo "waiting for kube-dns to be available"; kubectl get pods --all-namespaces; done
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -139,20 +139,20 @@ jobs:
           curl -o bash_unit "https://raw.githubusercontent.com/pgrange/bash_unit/master/bash_unit"
           chmod +x bash_unit
           
-          echo "[Unit]" > /etc/systemd/system/cri-docker.service
-          echo "Description=CRI-Dockerd service" >> /etc/systemd/system/cri-docker.service
-          echo "Wants=docker.service" >> /etc/systemd/system/cri-docker.service
-          echo "After=docker.service" >> /etc/systemd/system/cri-docker.service
-          echo "" >> /etc/systemd/system/cri-docker.service
-          echo "[Service]" >> /etc/systemd/system/cri-docker.service
-          echo "Type=simple" >> /etc/systemd/system/cri-docker.service
-          echo "ExecStart=/usr/local/bin/cri-dockerd" >> /etc/systemd/system/cri-docker.service
-          echo "User=root" >> /etc/systemd/system/cri-docker.service
-          echo "Environment=DOCKER_HOST=localhost" >> /etc/systemd/system/cri-docker.service
-          echo "Restart=on-failure" >> /etc/systemd/system/cri-docker.service
-          echo "" >> /etc/systemd/system/cri-docker.service
-          echo "[Install]" >> /etc/systemd/system/cri-docker.service
-          echo "WantedBy=multi-user.target" >> /etc/systemd/system/cri-docker.service
+          sudo echo "[Unit]" > /etc/systemd/system/cri-docker.service
+          sudo echo "Description=CRI-Dockerd service" >> /etc/systemd/system/cri-docker.service
+          sudo echo "Wants=docker.service" >> /etc/systemd/system/cri-docker.service
+          sudo echo "After=docker.service" >> /etc/systemd/system/cri-docker.service
+          sudo echo "" >> /etc/systemd/system/cri-docker.service
+          sudo echo "[Service]" >> /etc/systemd/system/cri-docker.service
+          sudo echo "Type=simple" >> /etc/systemd/system/cri-docker.service
+          sudo echo "ExecStart=/usr/local/bin/cri-dockerd" >> /etc/systemd/system/cri-docker.service
+          sudo echo "User=root" >> /etc/systemd/system/cri-docker.service
+          sudo echo "Environment=DOCKER_HOST=localhost" >> /etc/systemd/system/cri-docker.service
+          sudo echo "Restart=on-failure" >> /etc/systemd/system/cri-docker.service
+          sudo echo "" >> /etc/systemd/system/cri-docker.service
+          sudo echo "[Install]" >> /etc/systemd/system/cri-docker.service
+          sudo echo "WantedBy=multi-user.target" >> /etc/systemd/system/cri-docker.service
           
           curl -Lo cri-dockerd.tgz https://github.com/Mirantis/cri-dockerd/releases/download/v0.3.17/cri-dockerd-0.3.17.amd64.tgz
           tar -xzvf cri-dockerd.tgz

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -136,6 +136,7 @@ jobs:
       
       - name: Install prerequisites
         run: |
+          set -x
           curl -o bash_unit "https://raw.githubusercontent.com/pgrange/bash_unit/master/bash_unit"
           chmod +x bash_unit
           
@@ -148,15 +149,13 @@ jobs:
           sudo install cri-docker.service /etc/systemd/system
           sudo install cri-docker.socket /etc/systemd/system
           sudo sed -i -e 's,/usr/bin/cri-dockerd,/usr/local/bin/cri-dockerd,' /etc/systemd/system/cri-docker.service
-          sudo systemctl daemon-reload
           sudo systemctl enable cri-docker.service
           sudo systemctl enable --now cri-docker.socket
           sudo systemctl daemon-reload
-          journalctl -u cri-docker.service
           echo "8"
-          sudo service cri-docker.service status
-          sudo service cri-docker.socket status
-          sudo systemctl status cri-docker
+          sudo service cri-docker status || true
+          sudo systemctl status cri-docker || true
+          journalctl -u cri-docker.service
           echo "9"
           rm cri-dockerd.tgz
           rm cri-docker.service

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -175,7 +175,8 @@ jobs:
 
       - name: Ensure kubernetes is ready
         run: |
-          kubectl get pods -A
+          set -x
+          kubectl minikube get pods -A
           kubectl cluster-info
           JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl -n kube-system get pods -lk8s-app=kube-dns -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1;echo "waiting for kube-dns to be available"; kubectl get pods --all-namespaces; done
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -137,54 +137,38 @@ jobs:
       - name: Install prerequisites
         run: |
           set -x
+          
+          docker save -o k8s-wait-for-test pegasystems/k8s-wait-for:test
+          
           curl -o bash_unit "https://raw.githubusercontent.com/pgrange/bash_unit/master/bash_unit"
           chmod +x bash_unit
           
-          curl -Lo runc.amd64 https://github.com/opencontainers/runc/releases/download/v1.3.0/runc.amd64
-          sudo install runc.amd64 /usr/local/bin/runc
-          rm runc.amd64
+          for pkg in docker.io docker-doc docker-compose docker-compose-v2 podman-docker containerd runc; do sudo apt-get remove $pkg; done
           
-          curl -Lo cri-dockerd.tgz https://github.com/Mirantis/cri-dockerd/releases/download/v0.3.17/cri-dockerd-0.3.17.amd64.tgz
-          tar -xzvf cri-dockerd.tgz
-          sudo install -o root -g root -m 0755 cri-dockerd/cri-dockerd /usr/local/bin/cri-dockerd
-
-          curl -Lo cri-docker.service https://raw.githubusercontent.com/Mirantis/cri-dockerd/master/packaging/systemd/cri-docker.service
-          curl -Lo cri-docker.socket https://raw.githubusercontent.com/Mirantis/cri-dockerd/master/packaging/systemd/cri-docker.socket
-          sudo install cri-docker.service /etc/systemd/system
-          sudo install cri-docker.socket /etc/systemd/system
-          sudo sed -i -e 's,/usr/bin/cri-dockerd,/usr/local/bin/cri-dockerd,' /etc/systemd/system/cri-docker.service
+          sudo apt-get update
+          sudo apt-get install ca-certificates curl
+          sudo install -m 0755 -d /etc/apt/keyrings
+          sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+          sudo chmod a+r /etc/apt/keyrings/docker.asc
           
-          which cri-dockerd
-          cri-dockerd --help
+          echo \
+            "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+            $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" | \
+            sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+          sudo apt-get update
           
-          sudo systemctl enable cri-docker.service
-          sudo systemctl enable --now cri-docker.socket
-          sudo systemctl daemon-reload
-          echo "8"
-          sudo systemctl status cri-docker || true
-          journalctl -xeu cri-docker.service
-          echo "9"
-          rm cri-dockerd.tgz
-          rm cri-docker.service
-          rm cri-docker.socket
+          sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+          sudo docker run hello-world
           
-          curl -Lo crictl.tar.gz https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.33.0/crictl-v1.33.0-linux-amd64.tar.gz
-          tar zxvf crictl.tar.gz -C /usr/local/bin
-          rm -f crictl.tar.gz
-          
-          curl -Lo cni-plugins.tgz https://github.com/containernetworking/plugins/releases/download/v1.7.1/cni-plugins-linux-amd64-v1.7.1.tgz
-          sudo mkdir -p /opt/cni/bin
-          sudo tar -xf cni-plugins.tgz -C /opt/cni/bin
-          rm cni-plugins.tgz
           
           curl -Lo kubectl https://dl.k8s.io/release/v1.33.1/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
           curl -Lo minikube https://github.com/kubernetes/minikube/releases/latest/download/minikube-linux-amd64 && install minikube-linux-amd64 /usr/local/bin/minikube && rm minikube-linux-amd64
           mkdir -p $HOME/.kube $HOME/.minikube
           touch $KUBECONFIG
           sudo apt-get install -y conntrack
-          minikube start --vm-driver=none --kubernetes-version=v1.31.0
+          minikube start --vm-driver=docker --kubernetes-version=v1.31.0
           echo "minikube startup complete."
-          docker save -o k8s-wait-for-test pegasystems/k8s-wait-for:test
+          
           minikube image load k8s-wait-for-test
           echo "Sleeping for 10s..."
           sleep 10

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -157,6 +157,7 @@ jobs:
           sudo systemctl enable --now cri-docker.socket
           echo "8"
           sudo systemctl status cri-docker
+          echo "9"
           rm cri-dockerd.tgz
           rm cri-docker.service
           rm cri-docker.socket

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -176,7 +176,7 @@ jobs:
       - name: Ensure kubernetes is ready
         run: |
           set -x
-          minikube kubectl get pods -A
+          minikube kubectl get pods --all-namespaces
           kubectl cluster-info
           JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl -n kube-system get pods -lk8s-app=kube-dns -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1;echo "waiting for kube-dns to be available"; kubectl get pods --all-namespaces; done
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -154,9 +154,10 @@ jobs:
           echo "systemctl daemon-reload"
           sudo systemctl daemon-reload
           echo "7"
+          sudo systemctl enable cri-docker.service
+          echo "7.5"
           sudo systemctl enable --now cri-docker.socket
           echo "8"
-          sudo systemctl restart docker
           echo "8.5"
           sudo systemctl status cri-docker
           echo "9"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -136,8 +136,6 @@ jobs:
       
       - name: Install prerequisites
         run: |
-          set -x
-          
           docker save -o k8s-wait-for-test pegasystems/k8s-wait-for:test
           
           curl -o bash_unit "https://raw.githubusercontent.com/pgrange/bash_unit/master/bash_unit"
@@ -177,9 +175,6 @@ jobs:
 
       - name: Ensure kubernetes is ready
         run: |
-          set -x
-          minikube kubectl -- get pods -A
-          kubectl --help
           kubectl cluster-info
           JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl -n kube-system get pods -lk8s-app=kube-dns -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1;echo "waiting for kube-dns to be available"; kubectl get pods --all-namespaces; done
 

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,5 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Environment-dependent path to Maven home directory
+/mavenHomeManager.xml

--- a/.idea/k8s-wait-for.iml
+++ b/.idea/k8s-wait-for.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="21" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/k8s-wait-for.iml" filepath="$PROJECT_DIR$/.idea/k8s-wait-for.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.21 AS builder
+FROM alpine:3.22 AS builder
 
 ARG TARGETARCH
 
@@ -9,7 +9,7 @@ RUN apk add --update --no-cache ca-certificates curl jq \
     && ls -al /usr/local/bin/kubectl \
     && chmod +x /usr/local/bin/kubectl
 
-FROM alpine:3.21
+FROM alpine:3.22
 ARG VCS_REF
 ARG BUILD_DATE
 


### PR DESCRIPTION
Automated builds stopped due to ubuntu-20.04 base image deprecation.

Also noticed that we were running on a very old version of k8s (avoiding 1.24 due to figuring out how to work with CRI) -- update k8s to 1.31.0.