### PR TITLE
BUG-959519 - capturing error statements from k8s-wait-for and allowing it to proceed to up to push image.

### DIFF
--- a/tests/test_wait_for_retry
+++ b/tests/test_wait_for_retry
@@ -1,12 +1,15 @@
 test_wait_for_no_retries() {
+    set +e
     export KUBECTL_TRACKER=$(pwd)/resources/kubectl-tracker
     rm -f $KUBECTL_TRACKER
     PATH=$(pwd)/resources:$PATH
     export MAX_RETRIES=0
     
     ../wait_for.sh job test-job
+    exit_code=$?
+    set -e
 
-    assert "test $? -eq 1" "The wait_for job should not have retried and should have given exit code 1"
+    assert "test $exit_code -eq 1" "The wait_for job should not have retried and should have given exit code 1"
 }
 
 test_wait_for_one_retry() {


### PR DESCRIPTION
Looks like from the test function, after invoking `wait_for.sh` script, the test function was terminating and not executing the assertion and build was failing.

Added set +e to turn off exit immediately on error and proceed to next lines.